### PR TITLE
CI: Fixing AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ environment:
     - RUBY_VERSION: 22
     - RUBY_VERSION: 21
     - RUBY_VERSION: 200
+    - RUBY_VERSION: "jruby-9.0.4.0"
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+cache:
+  - vendor/bundle
+
+environment:
+  matrix:
+    - RUBY_VERSION: 25
+    - RUBY_VERSION: 24
+    - RUBY_VERSION: 23
+    - RUBY_VERSION: 22
+    - RUBY_VERSION: 21
+    - RUBY_VERSION: 200
+    - RUBY_VERSION: jruby
+
+install:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle config --local path vendor/bundle
+  - bundle install
+
+build: off
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
     - RUBY_VERSION: 22
     - RUBY_VERSION: 21
     - RUBY_VERSION: 200
-    - RUBY_VERSION: jruby
+    - RUBY_VERSION: jruby-9.1
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ environment:
     - RUBY_VERSION: 22
     - RUBY_VERSION: 21
     - RUBY_VERSION: 200
-    - RUBY_VERSION: jruby-9.1
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ environment:
     - RUBY_VERSION: 22
     - RUBY_VERSION: 21
     - RUBY_VERSION: 200
-    - RUBY_VERSION: "jruby-9.0.4.0"
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%


### PR DESCRIPTION
AppVeyor builds currently fail, seemingly due to `bundle install` not being executed:

```
bundle exec rake test
C:/Ruby193/lib/ruby/gems/1.9.1/gems/bundler-1.16.1/lib/bundler/resolver.rb:289:in `block in verify_gemfile_dependencies_are_found!': Could not find gem 'cucumber x86-mingw32' in any of the gem sources listed in your Gemfile. (Bundler::GemNotFound)
	from C:/Ruby193/lib/ruby/gems/
```

I've simply added an `appveyor.yml` config file to resolve this. :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xtrasimplicity/shell-strike/4)
<!-- Reviewable:end -->
