### PR TITLE
Adding an Event System

### DIFF
--- a/lib/shell_strike.rb
+++ b/lib/shell_strike.rb
@@ -1,4 +1,5 @@
 require "shell_strike/version"
+require "shell_strike/events"
 require "shell_strike/ssh"
 require "shell_strike/exceptions"
 require "shell_strike/result"
@@ -69,6 +70,13 @@ class ShellStrike
   # @return An array of Host objects
   def failed_hosts
     @failed_hosts ||= []
+  end
+
+  # Subscribe to an event
+  # @param event_name [Symbol] The event to subscribe to.
+  # @yieldparam block The block to execute
+  def on(event_name, &block)
+    ShellStrike::Events.on(event_name, &block)
   end
 
   private

--- a/lib/shell_strike.rb
+++ b/lib/shell_strike.rb
@@ -41,6 +41,7 @@ class ShellStrike
           store_valid_credentials(host, username, password)
         else
           credential_failure_count += 1
+          ShellStrike::Events.emit(:credentials_failed, host, username, password)
         end
       end
       
@@ -96,6 +97,8 @@ class ShellStrike
   def store_valid_credentials(host, username, password)
     identified_credentials[host.to_uri] = [] unless identified_credentials.has_key? host.to_uri
     identified_credentials[host.to_uri] << [username, password]
+
+    ShellStrike::Events.emit(:credentials_identified, host, username, password)
   end
 
   # Stores the unreachable host into the unreachable hosts array

--- a/lib/shell_strike/events.rb
+++ b/lib/shell_strike/events.rb
@@ -1,0 +1,28 @@
+require 'events'
+
+module ShellStrike::Events
+  class Emitter
+    include ::Events::Emitter
+  end
+  private_constant :Emitter
+
+  def self.on(event_name, &block)
+    raise ShellStrike::InvalidEvent unless event_name.is_a?(Symbol)
+
+    instance.on(event_name, &block)
+  end
+
+  protected
+  
+  def self.emit(event_name, *args)
+    raise ShellStrike::InvalidEvent unless event_name.is_a?(Symbol)
+
+    instance.emit(event_name, *args)
+  end
+    
+  private
+
+  def self.instance
+    @emitter ||= Emitter.new
+  end
+end

--- a/lib/shell_strike/exceptions.rb
+++ b/lib/shell_strike/exceptions.rb
@@ -2,4 +2,5 @@ class ShellStrike
   class HostsNotDefined < StandardError; end
   class UsernamesNotDefined < StandardError; end
   class PasswordsNotDefined < StandardError; end
+  class InvalidEvent < StandardError; end
 end

--- a/shell_strike.gemspec
+++ b/shell_strike.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-ssh"
+  spec.add_dependency "events"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/spec/shell_strike/event_spec.rb
+++ b/spec/shell_strike/event_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe ShellStrike::Events do
+  describe '.on' do
+    describe 'with an invalid event' do
+      it 'raises a ShellStrike::InvalidEvent error' do
+        expect {
+          ShellStrike::Events.on(nil)
+        }.to raise_error(ShellStrike::InvalidEvent)
+      end
+    end
+
+    it 'subscribes to the event' do
+      @x = 0
+      ShellStrike::Events.on(:my_new_event) do
+        @x = 1
+      end
+
+      ShellStrike::Events.emit(:my_new_event)
+
+      expect(@x).to eq(1)
+    end
+  end
+
+  describe '.emit' do
+    describe 'with an invalid event' do
+      it 'raises a ShellStrike::InvalidEvent error' do
+        expect {
+          ShellStrike::Events.emit(nil)
+        }.to raise_error(ShellStrike::InvalidEvent)
+      end
+    end
+  end
+end

--- a/spec/shell_strike_spec.rb
+++ b/spec/shell_strike_spec.rb
@@ -83,6 +83,37 @@ RSpec.describe ShellStrike do
     end
   end
 
+  describe '#identify_credentials!' do
+    let(:username) { 'root' }
+    let(:password) { 'password' }
+    let(:host) { ShellStrike::Host.new('192.168.1.1') }
+    let(:instance) { ShellStrike.new([host], [username], [password]) }
+
+    context 'when the host is online' do
+      before { stub_host_as_online(host.host, host.port) }
+
+      context 'and the credentials are valid' do
+        before { stub_valid_ssh_credentials(host.host, host.port, [ [username, password] ]) }
+
+        it 'triggers the :credentials_identified event' do
+          expect(ShellStrike::Events).to receive(:emit).with(:credentials_identified, host, username, password)
+    
+          instance.identify_credentials!
+        end
+      end
+
+      context 'and the credentials are invalid' do
+        before { mock_authentication_failure(host.host, host.port) }
+
+        it 'triggers the :credentials_failed event' do
+          expect(ShellStrike::Events).to receive(:emit).with(:credentials_failed, host, username, password)
+    
+          instance.identify_credentials!
+        end
+      end
+    end
+  end
+
   describe '#on' do
     let(:instance) { ShellStrike.new([ShellStrike::Host.new('192.168.1.1')], ['root'], ['password']) }
 

--- a/spec/shell_strike_spec.rb
+++ b/spec/shell_strike_spec.rb
@@ -83,4 +83,28 @@ RSpec.describe ShellStrike do
     end
   end
 
+  describe '#on' do
+    let(:instance) { ShellStrike.new([ShellStrike::Host.new('192.168.1.1')], ['root'], ['password']) }
+
+    context 'with an invalid event' do
+      it 'raises a ShellStrike::InvalidEvent error' do
+        expect {
+          instance.on(nil)
+        }.to raise_error(ShellStrike::InvalidEvent)
+      end
+    end
+
+    context 'with a valid event' do
+      it 'subscribes to the event' do
+        @x = 0
+        instance.on(:my_new_event) do
+          @x = 1
+        end
+
+        ShellStrike::Events.send(:emit, :my_new_event)
+
+        expect(@x).to eq(1)
+      end
+    end
+  end
 end

--- a/test/shared/ssh_helper.rb
+++ b/test/shared/ssh_helper.rb
@@ -20,11 +20,15 @@ module SSHHelper
   end
 
   def stub_valid_ssh_credentials(host, port, valid_credentials)
-    allow(ShellStrike::Ssh).to receive(:valid_credentials?).with(an_object_having_attributes(host: host, port: port), anything, anything).and_return(false)
+    mock_authentication_failure(host, port)
 
     
     valid_credentials.each do |username, password|
      allow(ShellStrike::Ssh).to receive(:valid_credentials?).with(an_object_having_attributes(host: host, port: port), username, password).and_return(true)
     end
+  end
+
+  def mock_authentication_failure(host, port)
+    allow(ShellStrike::Ssh).to receive(:valid_credentials?).with(an_object_having_attributes(host: host, port: port), anything, anything).and_return(false)
   end
 end


### PR DESCRIPTION
Adding a simple event system, so that users can access "real-time" data pertaining to credential identification.

Usage:
```
instance = ShellStrike.new(hosts, usernames, passwords)

instance.on(:credentials_identified) do |host, username, password|
  puts "Successfully identified credentials for #{host.to_uri}: #{username} / #{password}"
end

instance.on(:credentials_failed) do |host, username, password|
  # Do something when credential identification fails
end

instance.identify_credentials!
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xtrasimplicity/shell-strike/5)
<!-- Reviewable:end -->
